### PR TITLE
removing import universal-cookies from addrecipe page

### DIFF
--- a/src/pages/addrecipe.js
+++ b/src/pages/addrecipe.js
@@ -1,9 +1,6 @@
 import React from 'react'
 import Layout from '../components/Layout'
-// import styled from 'styled-components'
 import * as El from './../components/AddRecipe/style'
-// import * as Cookies from './../components/Cookie/'
-import Cookies from 'universal-cookie'
 import axios from 'axios'
 // import IngredientInput from '../components/IngredientInput.js'
 


### PR DESCRIPTION
removing unneeded import from addrecipe page(it was universal-cookie) 